### PR TITLE
Add template manifest for WindowsPerf 3.8.0.0

### DIFF
--- a/manifests/a/Arm/WindowsPerf/3.8.0.0/Arm.WindowsPerf.installer.yaml
+++ b/manifests/a/Arm/WindowsPerf/3.8.0.0/Arm.WindowsPerf.installer.yaml
@@ -1,0 +1,14 @@
+# Created using wingetcreate 1.6.4.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
+
+PackageIdentifier: Arm.WindowsPerf
+PackageVersion: 3.8.0.0
+InstallerLocale: en-US
+InstallerType: wix
+ProductCode: '{1ACE4754-BF60-454A-9E6D-861DE875AE83}'
+Installers:
+- InstallerUrl: https://gitlab.com/api/v4/projects/40381146/packages/generic/windowsperf/3.8.0/wperf-installer.msi
+  Architecture: arm64
+  InstallerSha256: C96B1DAEE6E2690829E36533AD2F308031CB688F5DBC0E78E14A6E74BBCC07E1
+ManifestType: installer
+ManifestVersion: 1.6.0

--- a/manifests/a/Arm/WindowsPerf/3.8.0.0/Arm.WindowsPerf.locale.en-US.yaml
+++ b/manifests/a/Arm/WindowsPerf/3.8.0.0/Arm.WindowsPerf.locale.en-US.yaml
@@ -1,0 +1,12 @@
+# Created using wingetcreate 1.6.4.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
+
+PackageIdentifier: Arm.WindowsPerf
+PackageVersion: 3.8.0.0
+PackageLocale: en-US
+Publisher: Arm
+PackageName: WindowsPerf
+License: BSD-3
+ShortDescription: WindowsPerf is (Linux perf inspired) Windows on Arm performance profiling tool
+ManifestType: defaultLocale
+ManifestVersion: 1.6.0

--- a/manifests/a/Arm/WindowsPerf/3.8.0.0/Arm.WindowsPerf.yaml
+++ b/manifests/a/Arm/WindowsPerf/3.8.0.0/Arm.WindowsPerf.yaml
@@ -1,0 +1,8 @@
+# Created using wingetcreate 1.6.4.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
+
+PackageIdentifier: Arm.WindowsPerf
+PackageVersion: 3.8.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.6.0


### PR DESCRIPTION
# Description

This manifest was created using the `wingetcreate new` command after uploading a test artifact to ` https://gitlab.com/api/v4/projects/40381146/packages/generic/windowsperf/3.8.0/wperf-installer.msi`. This was tested with the following steps
1. Enable local manifests on winget with `winget settings --enable LocalManifestFiles` on an admin shell.
2. Verify the manifest going to the folder with the yamls and running `winget validate --manifest .\`
3. Install WindowsPerf with `winget install --manifest .`
4. Uninstall with `winget uninstall WindowsPerf`
